### PR TITLE
Tdd twiddle-wakka fix/mirgration for rspec 3.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .bundle
 .rvmrc
 .ruby-version
+.ruby-gemset
 .yardoc
 .rake_tasks~
 Gemfile.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: ruby
+
+before_install: "gem install bundler"
+install:        "bundle install"
+
+script: "rake"
+
+rvm:
+  - 1.9.3
+  - 2.0
+  - 2.1
+  - 2.2

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,8 @@
+source 'https://rubygems.org'
+
+# Specify your gem's dependencies in gemspec
+gemspec
+
+gem 'pry'
+# Put other dynamic build / pre-release gems here.
+# Putting gems in a Gemfile does not install them during gem install foo! - Only developement hybrid environments use this.

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,5 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in gemspec
 gemspec
 
-gem 'pry'
 # Put other dynamic build / pre-release gems here.
 # Putting gems in a Gemfile does not install them during gem install foo! - Only developement hybrid environments use this.

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,15 @@
+#!/usr/bin/env rake
+require "bundler/gem_tasks"
+require 'rspec/core/rake_task'
+
+task :default => [:spec]
+
+RSpec::Core::RakeTask.new(:spec) do |t|
+  t.pattern = Dir.glob('spec/**/*_spec.rb')
+end
+
+# Run test with verbose output
+RSpec::Core::RakeTask.new(:spec_verbose) do |t|
+  t.pattern = Dir.glob('spec/**/*_spec.rb')
+  t.rspec_opts = '--format documentation'
+end

--- a/lib/metascan.rb
+++ b/lib/metascan.rb
@@ -8,12 +8,14 @@ module Metascan
     :scan_file            => "https://scan.metascan-online.com/v2/file",
     :results_by_data_id   => "https://scan.metascan-online.com/v2/file",
     :results_by_file_hash => "https://hashlookup.metascan-online.com/v2/hash",
-    :scan_ip              => "https://ipscan.metascan-online.com/v1/scan/"
+    :scan_ip              => "https://ipscan.metascan-online.com/v1/scan"
   }
 
   # a miserable pile of library classes!
   require_relative 'metascan/scan'
   require_relative 'metascan/client'
   require_relative 'metascan/batch'
+
+  class ScanDataIdMissing < StandardError; end
 
 end

--- a/lib/metascan.rb
+++ b/lib/metascan.rb
@@ -7,7 +7,8 @@ module Metascan
   PATHS = {
     :scan_file            => "https://scan.metascan-online.com/v2/file",
     :results_by_data_id   => "https://scan.metascan-online.com/v2/file",
-    :results_by_file_hash => "https://hashlookup.metascan-online.com/v2/hash"
+    :results_by_file_hash => "https://hashlookup.metascan-online.com/v2/hash",
+    :scan_ip              => "https://ipscan.metascan-online.com/v1/scan/"
   }
 
   # a miserable pile of library classes!

--- a/lib/metascan/scan.rb
+++ b/lib/metascan/scan.rb
@@ -73,7 +73,7 @@ module Metascan
     # Fails if called before @data_id is set (when self.run is called, or
     # my Batch runs me)
     def retrieve_results
-      raise ScanDataIdMissing, "Scan " if self.data_id.nil?
+      raise ScanDataIdMissing, "Scan data_id is missing. Scan may not have been submitted." if self.data_id.nil?
       request = Typhoeus::Request.new(
         @rest_ip + '/' + @data_id,
         headers: {

--- a/lib/metascan/version.rb
+++ b/lib/metascan/version.rb
@@ -1,0 +1,3 @@
+module Metascan
+  VERSION = "0.1.1"
+end

--- a/metascan.gemspec
+++ b/metascan.gemspec
@@ -1,22 +1,21 @@
+$LOAD_PATH.unshift File.expand_path('../lib', __FILE__)
+gemname = "metascan"
+require "#{gemname}/version"
+
 Gem::Specification.new do |s|
-  s.name        = 'metascan'
-  s.version     = '0.1.0'
+  s.name        = gemname
+  s.version     = Metascan::VERSION
   s.date        = '2014-04-25'
   s.summary     = "Scan files for viruses using the Metascan public API."
   s.description = "Allows virus scanning files using the Metascan public API. https://www.metascan-online.com/en/public-api"
   s.authors     = ["Grayson Chao"]
   s.email       = 'graysonchao@berkeley.edu'
-  s.files       = [
-    "lib/metascan.rb",
-    "lib/metascan/client.rb",
-    "lib/metascan/batch.rb",
-    "lib/metascan/scan.rb"
-  ]
-  s.homepage    =
-    'http://rubygems.org/gems/metascan'
-  s.license       = 'MIT'
-  s.add_development_dependency 'rspec'
-  s.add_development_dependency 'webmock'
-  s.add_runtime_dependency 'typhoeus',
-    [">= 0.6.8"]
+  s.files       = `git ls-files`.split($\)
+  s.test_files  = s.files.grep(%r{^(test|spec|features)/})
+  s.homepage    = 'https://rubygems.org/gems/metascan'
+  s.license     = 'MIT'
+  s.add_development_dependency('bump', '~> 0.3')
+  s.add_development_dependency('rspec', '~> 3.3')
+  s.add_development_dependency('webmock', '~> 1.21')
+  s.add_runtime_dependency('typhoeus', "~> 0.6.8")
 end

--- a/spec/batch_spec.rb
+++ b/spec/batch_spec.rb
@@ -1,6 +1,5 @@
 require 'rspec'
 require 'spec_helper'
-require_relative '../metascan'
 
 describe Metascan::Batch do
   before :all do
@@ -24,7 +23,7 @@ describe Metascan::Batch do
       it 'raises error' do
         expect {
           @batch.add "Not a Metascan::Scan object"
-        }.to raise_error
+        }.to raise_error TypeError
       end
     end
   end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -1,6 +1,5 @@
 require 'rspec'
 require 'spec_helper'
-require_relative '../metascan'
 
 describe Metascan::Client do
   before :each do

--- a/spec/scan_spec.rb
+++ b/spec/scan_spec.rb
@@ -1,6 +1,6 @@
 require 'rspec'
 require 'spec_helper'
-require_relative '../metascan'
+
 
 describe Metascan::Scan do
   before :each do
@@ -14,11 +14,11 @@ describe Metascan::Scan do
       @scan.data_id.should_not be(nil)
     end
   end
-  
+
   describe "#clean?" do
     context "when scan_all_result_i is 0" do
       it "returns true" do
-        @scan.results = { 
+        @scan.results = {
           "scan_results" => {
             "scan_all_result_i" => 0,
             "progress_percentage" => 100
@@ -30,7 +30,7 @@ describe Metascan::Scan do
 
     context "when scan_all_result_i is not 0" do
       it "returns false" do
-        @scan.results = { 
+        @scan.results = {
           "scan_results" => {
             "scan_all_result_i" => 1,
             "progress_percentage" => 100
@@ -64,7 +64,7 @@ describe Metascan::Scan do
 
     context 'before .run' do
       it 'errors' do
-        expect {@scan.retrieve_results}.to raise_error
+        expect {@scan.retrieve_results}.to raise_error Metascan::ScanDataIdMissing
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,10 +1,14 @@
+require 'pry'
 require 'webmock/rspec'
 require 'json'
+$LOAD_PATH.unshift File.expand_path('../lib', __FILE__)
+require 'metascan'
 
 WebMock.disable_net_connect!(allow_localhost: true)
 
 response_stubs = {
   :scan_file => JSON.dump({
+    "rest_ip" => Metascan::PATHS[:scan_file],
     "data_id" => "sample_data_id",
     "progress_percentage" => 100
   }),
@@ -30,10 +34,15 @@ RSpec.configure do |cfg|
   cfg.before(:each) do
     stub_request(:post, Metascan::PATHS[:scan_file]).
       to_return(:status => 200, :body => response_stubs[:scan_file], :headers => {})
-    stub_request(:get, "#{Metascan::PATHS[:results_by_data_id]}sample_data_id").
+    stub_request(:get, "#{Metascan::PATHS[:results_by_data_id]}/sample_data_id").
       to_return(status: 200, body: response_stubs[:results_by_data_id], headers: {})
     stub_request(:get, Metascan::PATHS[:results_by_file_hash]).
       to_return(status: 200, body: response_stubs[:results_by_file_hash], headers: {})
+  end
+
+  cfg.expect_with :rspec do |c|
+    # ...explicitly enable both
+    c.syntax = [:should, :expect]
   end
 
 end
@@ -48,7 +57,7 @@ def switch_scan_dirt(dirt)
         "progress_percentage" => 100
       },
     })
-    stub_request(:get, "#{Metascan::PATHS[:results_by_data_id]}sample_data_id").
+    stub_request(:get, "#{Metascan::PATHS[:results_by_data_id]}/sample_data_id").
       to_return(status: 200, body: dirty_response, headers: {})
   else
     clean_response = JSON.dump({
@@ -58,7 +67,7 @@ def switch_scan_dirt(dirt)
         "progress_percentage" => 100
       }
     })
-    stub_request(:get, "#{Metascan::PATHS[:results_by_data_id]}sample_data_id").
+    stub_request(:get, "#{Metascan::PATHS[:results_by_data_id]}/sample_data_id").
       to_return(status: 200, body: clean_response, headers: {})
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,3 @@
-require 'pry'
 require 'webmock/rspec'
 require 'json'
 $LOAD_PATH.unshift File.expand_path('../lib', __FILE__)


### PR DESCRIPTION
```
adding some normal gem build methods (rake, twiddle-wakka for rspec)

update .gitignore to add gemset

syntax for gemspec was very manual

adding versioning compliant with bump

squash bug in uri parser

migrating to rspec 3.3, squash spec bugs, and add explicit error raising
```
